### PR TITLE
Fix for Compiler.groovy class including URL scheme "file:" in source file name in compile output buffer

### DIFF
--- a/src/main/groovy/org/grumblesmurf/malabar/Compiler.groovy
+++ b/src/main/groovy/org/grumblesmurf/malabar/Compiler.groovy
@@ -82,7 +82,7 @@ class Compiler
                                              it.getMessage(null));
                     LOGGER.debug(info);
                     try {                           
-                        def src = new File(it.source.toUri().toString()).path;
+                        def src = new File(it.source.toUri().toString()).path.replace("file:", "");
                         def start = [src, it.lineNumber].join(":");
                         def message = it.getMessage(null).replace(start + ":", "");
                         println([it.kind, Utils.standardizeSlashes(src),


### PR DESCRIPTION
Matt, this is a follow on to our fix for issue m0smith/malabar-mode#95, which got the compile functionality working for java 6 on linux, but appears to have created a regression for linux and I assume windows and others?

The string for the source file that gets printed in the compile output buffer is a full URL beginning with the scheme "file:".  This scheme at the front confuses the compilation-mode of the buffer, so that when you try to jump to an error listed there it cannot do so.  The file string gets truncated for some reason.

The solution is to remove the "file:" from the front of the string.

I've also removed the TAB chars from Compiler.groovy.
