### PR TITLE
Fixed continuously expanding compileClassPath.

### DIFF
--- a/src/main/groovy/org/grumblesmurf/malabar/Classpath.groovy
+++ b/src/main/groovy/org/grumblesmurf/malabar/Classpath.groovy
@@ -134,7 +134,10 @@ class Classpath
         if (classMap.isEmpty()) {
             populateClassMap();
         }
-        populateExtraClassMap();
+
+		if (extraClassMap.isEmpty()) {
+			populateExtraClassMap();
+		}
 
         Utils.printAsLispList classMapEntry(name);
     }


### PR DESCRIPTION
The result of populateExtraClassMap() would be appended to extraClassMap
on each call to Classpath.getClasses(), resulting in constantly
expanding lists. The call to that method occurred regardless of whether
extraClassMap was empty, but the code's purpose seems to be a lazy
initialization of that data.
