### PR TITLE
Fix gradle integration

### DIFF
--- a/src/main/groovy/com/software_ninja/malabar/project/GradleProjectsCreator.groovy
+++ b/src/main/groovy/com/software_ninja/malabar/project/GradleProjectsCreator.groovy
@@ -21,17 +21,12 @@ public class GradleProjectsCreator {
   }
 
   public resolveDependencies(  model,  _repo, scope) {
-    def gradleScope = scope == 'runtime' ? 'COMPILE' : 'TEST';
-    println model.getClass().getName();
-    def deps0 = model.getDependencies();
-    println deps0;
-    def deps = deps0.grep({ it.scope == gradleScope });
-    println deps;
-    println "COntect Roots:" + model.contentRoots;
     def crs = model.contentRoots;
     def dependencies = model.dependencies;
 
-    [ dependencies : dependencies.collect({ it.file.absolutePath}), 
+    [ dependencies : dependencies.grep({ !it.exported } ).collect({ it.file.absolutePath }), 
+
+      classpath : dependencies.collect({ it.file.absolutePath }),
 
       resources: [] ,
 

--- a/src/main/groovy/com/software_ninja/malabar/project/GradleProjectsCreator.groovy
+++ b/src/main/groovy/com/software_ninja/malabar/project/GradleProjectsCreator.groovy
@@ -10,7 +10,7 @@ public class GradleProjectsCreator {
 
 
   public create( String repo, String pmfile){
-    def connection = GradleConnector.newConnector().forProjectDirectory(new File(pmfile)).useInstallation(new File("c:/Users/lpmsmith/.gradle/wrapper/dists/gradle-2.2.1-bin/88n1whbyjvxg3s40jzz5ur27/gradle-2.2.1")).connect();
+    def connection = GradleConnector.newConnector().forProjectDirectory(new File(pmfile).getParentFile()).connect();
     println " /// Connected"
     def builder = connection.model(IdeaProject.class);
     println " /// Made builder"

--- a/src/main/groovy/com/software_ninja/malabar/project/GradleProjectsCreator.groovy
+++ b/src/main/groovy/com/software_ninja/malabar/project/GradleProjectsCreator.groovy
@@ -45,9 +45,8 @@ public class GradleProjectsCreator {
 						       ]}).flatten() ,
 
 
-      elements:  "test" == scope ? model.compilerOutput.outputDir.toString() :
-                                   model.compilerOutput.testOutputDir.toString() ]
-
+      elements:  ([ "test" == scope ? model.compilerOutput.testOutputDir : model.compilerOutput.outputDir ] - null).collect { it.toString() }
+   ]
   }
 
   

--- a/src/main/groovy/com/software_ninja/malabar/project/MavenProjectHandler.groovy
+++ b/src/main/groovy/com/software_ninja/malabar/project/MavenProjectHandler.groovy
@@ -108,7 +108,8 @@ public class MavenProjectHandler {
       projectInfo['runtime']['sources'] +
       projectInfo['test']['elements'] +
       projectInfo['runtime']['elements'] +
-      projectInfo['test']['classpath'];
+      projectInfo['test']['classpath'] +
+      projectInfo['runtime']['classpath'] 
       def resourceCache = new ResourceCache();
       classpath.each({if(it != null) {println "IT:" + it; resourceCache.submit(it)}});
       bootClasspath.split(System.getProperty("path.separator")).each({if(it != null) resourceCache.submit(it)});


### PR DESCRIPTION
Fixes:
- Use gradle wrapper installed with package. It is best practice to check in the gradle wrapper with a gradle project. It might also be nice to allow a gradle installation to be set via system property. In any case, this is an improvement over the current hard coded directory.
- Set gradle dependencies to be the non-transitive dependencies and the classpath to be all dependencies. 
- The elisp expects elements to be a list.
- Add the runtime classpath to the classpath.
